### PR TITLE
Changed getBoundingClientRect() to getComputedStyle()

### DIFF
--- a/index.js
+++ b/index.js
@@ -14,7 +14,7 @@ function adjustMediaPadding() {
   const cell = gridCellDimensions();
 
   function setHeightFromRatio(media, ratio) {
-      const rect = media.getBoundingClientRect();
+	  const rect = getComputedStyle(media);
       const realHeight = rect.width / ratio;
       const diff = cell.height - (realHeight % cell.height);
       media.style.setProperty("padding-bottom", `${diff}px`);


### PR DESCRIPTION
When I tried to add borders to images by adding a new class to them, I got a lot of empty space below them. While the entire border technically fits in the grid, it looks wrong:
![2024_09_01-235244](https://github.com/user-attachments/assets/d4594a34-307a-4888-b8b1-5fbfaa10275b)

Even the normal images are somewhat off anyway:
![2024_09_01-235214](https://github.com/user-attachments/assets/01994b3b-704d-410a-ab8c-fb2b9ef83fcf)

By switching this function, my problem was solved (no blank space):
![2024_09_01-235811](https://github.com/user-attachments/assets/cb2f6e14-3145-4533-97cd-9b156bc7f602)

And other media was changed but not in a more 'broken' way than it was before:
![2024_09_01-235319](https://github.com/user-attachments/assets/5e37725f-4b20-4c2f-8692-a0c0e5abfd30)