### PR TITLE
Improved Documentation For Inept Users

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,9 +18,8 @@ make
 ```
 3. You can figure out the rest from there idk I'm not doing this
 
-### Regular Users
-[There is currently no plug & play method to build websites using the Monospace Web.](https://pbs.twimg.com/media/GYWlOmEXQAA9nWF?format=png&name=small)
 
+### [Regular Users](https://pbs.twimg.com/media/GYWlOmEXQAA9nWF?format=png&name=small)
 1. Install [Pandoc](https://pandoc.org/), if you are running Windows, the version of the installer that you want is "windows-x86_64".
 2. Ignore the other dependency. It has no easy install method and all it does is automatically refresh your website when you make edits. You can just close the tab and open the html file when you make an edit.
 3. Create your website as a markdown file, using Pandoc's markdown formattng. [(Here is an example file)](https://raw.githubusercontent.com/owickstrom/the-monospace-web/refs/heads/main/index.md), compare it to the [live website](https://owickstrom.github.io/the-monospace-web/) to figure out what makes what. You can also [click here](https://garrettgman.github.io/rmarkdown/authoring_pandoc_markdown.html) to see a more in-depth formatting guide.

--- a/README.md
+++ b/README.md
@@ -16,8 +16,6 @@ Here are a few example websites built using the Monospace Web:
 nix develop # or `direnv allow .`
 make
 ```
-3. Make the thing.
-<br><br>
 
 ### [🙍‍♂️](https://pbs.twimg.com/media/GYWlOmEXQAA9nWF?format=png&name=small) <!-- + People won't notice that the emoji is a link, makes for a good easter egg + --> Regular Users
 1. Install [Pandoc](https://pandoc.org/). If you are running Windows, the version of the installer that you want is `windows-x86_64`.
@@ -27,12 +25,13 @@ make
 	* index.css (This file controls the visual style for the website, modify only if you understand [CSS](https://www.youtube.com/watch?v=OEV8gMkCHXQ))
 	* template.html (This defines the structural layout for Monospace Web, don't touch it unless you understand [HTML](https://www.youtube.com/watch?v=ok-plXXHlWw))
 	* To download files from a repository, click on its name and it will allow you to inspect the individual file, then, on the right side of the page there should be a tiny button (next to a button that says "RAW") to download it.
-4  Create a folder anywhere in your computer and place the downloaded files inside. Your website will live here.
+4.  Create a folder anywhere in your computer and place the downloaded files inside. Your website will live here.
 5. Create your website as a markdown file, using Pandoc's markdown formattng. [Here is an example file](https://raw.githubusercontent.com/owickstrom/the-monospace-web/refs/heads/main/index.md), compare it to the [live website](https://owickstrom.github.io/the-monospace-web/) to figure out what makes what. You can also [click here](https://garrettgman.github.io/rmarkdown/authoring_pandoc_markdown.html) to see a more in-depth formatting guide.
 6. Open your command line, navigate to your project's folder, and write the following command `pandoc --toc -s --css reset.css --css index.css -i yoursourcefile.md -o output.html --template=template.html`
 	* You'll need to replace the file names with your own.
 	* You can and should automate this process with a batch script.
-7. test
+7. Congratulations! Open `output.html` to see your built website!
+8. There is also a video guide here: XXX todo XXX
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -11,18 +11,19 @@ Here are a few example websites built using the Monospace Web:
 
 ### Advanced Users
 1. Clone the repo
-2. Run nix or whatever
+2. Build using nix
 ```
 nix develop # or `direnv allow .`
 make
 ```
-
-3. ???
-4. Huh
-5. Okay but how do I convert the md
+3. You can figure out the rest from there idk I'm not doing this
 
 ### Regular Users
 [There is currently no plug & play method to build websites using the Monospace Web.](https://pbs.twimg.com/media/GYWlOmEXQAA9nWF?format=png&name=small)
+
+1. Install [Pandoc](https://pandoc.org/), if you are running Windows, the version of the installer that you want is "windows-x86_64".
+2. Ignore the other dependency. It has no easy install method and all it does is automatically refresh your website when you make edits. You can just close the tab and open the html file when you make an edit.
+3. Create your website as a markdown file, using Pandoc's markdown formattng. [(Here is an example file)](https://raw.githubusercontent.com/owickstrom/the-monospace-web/refs/heads/main/index.md), compare it to the [live website](https://owickstrom.github.io/the-monospace-web/) to figure out what makes what. You can also [click here](https://garrettgman.github.io/rmarkdown/authoring_pandoc_markdown.html) to see a more in-depth formatting guide.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -31,7 +31,6 @@ make
 	* You'll need to replace the file names with your own.
 	* You can and should automate this process with a batch script.
 7. Congratulations! Open `output.html` to see your built website!
-8. There is also a video guide here: XXX todo XXX
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Monospace fonts are dear to many of us. Some find them more readable, consistent, and beautiful, than their proportional alternatives. Maybe we’re just brainwashed from spending years in terminals? Or are we hopelessly nostalgic? I’m not sure. But I like them, and that’s why I started experimenting with all-monospace Web.
 
-Here are a few websites built using the Monospace Web:
+Here are a few example websites built using the Monospace Web:
 * Official Website: https://owickstrom.github.io/the-monospace-web/
 * Lucien Hinderling's Website : https://hinderling.github.io/
 * AZETTL Websolutions: https://azettl.net/

--- a/README.md
+++ b/README.md
@@ -2,14 +2,27 @@
 
 Monospace fonts are dear to many of us. Some find them more readable, consistent, and beautiful, than their proportional alternatives. Maybe we’re just brainwashed from spending years in terminals? Or are we hopelessly nostalgic? I’m not sure. But I like them, and that’s why I started experimenting with all-monospace Web.
 
-https://owickstrom.github.io/the-monospace-web/
+Here are a few websites built using the Monospace Web:
+* Official Website: https://owickstrom.github.io/the-monospace-web/
+* Lucien Hinderling's Website : https://hinderling.github.io/
+* AZETTL Websolutions: https://azettl.net/
 
-## Build
+## Installation & Usage
 
+### Advanced Users
+1. Clone the repo
+2. Run nix or whatever
 ```
 nix develop # or `direnv allow .`
 make
 ```
+
+3. ???
+4. Huh
+5. Okay but how do I convert the md
+
+### Regular Users
+https://pbs.twimg.com/media/GYWlOmEXQAA9nWF?format=png&name=small
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -9,20 +9,24 @@ Here are a few example websites built using the Monospace Web:
 
 ## Installation & Usage
 
-### Advanced Users
-1. Clone the repo
-2. Build using nix
+### 👩‍💻 Advanced Users
+1. Clone the repo.
+2. Build using Nix:
 ```
 nix develop # or `direnv allow .`
 make
 ```
-3. You can figure out the rest from there idk I'm not doing this
+3. Enjoy making an awesome website.
+<br><br>
 
-
-### [Regular Users](https://pbs.twimg.com/media/GYWlOmEXQAA9nWF?format=png&name=small)
-1. Install [Pandoc](https://pandoc.org/), if you are running Windows, the version of the installer that you want is "windows-x86_64".
+### [🙍‍♂️](https://pbs.twimg.com/media/GYWlOmEXQAA9nWF?format=png&name=small) <!-- + People won't notice that the emoji is a link, makes for a good easter egg + --> Regular Users
+1. Install [Pandoc](https://pandoc.org/), if you are running Windows, the version of the installer that you want is `windows-x86_64`.
 2. Ignore the other dependency. It has no easy install method and all it does is automatically refresh your website when you make edits. You can just close the tab and open the html file when you make an edit.
-3. Create your website as a markdown file, using Pandoc's markdown formattng. [(Here is an example file)](https://raw.githubusercontent.com/owickstrom/the-monospace-web/refs/heads/main/index.md), compare it to the [live website](https://owickstrom.github.io/the-monospace-web/) to figure out what makes what. You can also [click here](https://garrettgman.github.io/rmarkdown/authoring_pandoc_markdown.html) to see a more in-depth formatting guide.
+3. Create your website as a markdown file, using Pandoc's markdown formattng. [Here is an example file](https://raw.githubusercontent.com/owickstrom/the-monospace-web/refs/heads/main/index.md), compare it to the [live website](https://owickstrom.github.io/the-monospace-web/) to figure out what makes what. You can also [click here](https://garrettgman.github.io/rmarkdown/authoring_pandoc_markdown.html) to see a more in-depth formatting guide.
+4. Open your command line, navigate to your project's folder, and write the following command `pandoc --toc -s --css reset.css --css index.css -i yoursourcefile.md -o output.html --template=template.html`
+	* You'll need to replace the file names with your own.
+	* You can and should automate this process with a batch script.
+6. test
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -10,23 +10,29 @@ Here are a few example websites built using the Monospace Web:
 ## Installation & Usage
 
 ### 👩‍💻 Advanced Users
-1. Clone the repo.
+1. Clone the repository.
 2. Build using Nix:
 ```
 nix develop # or `direnv allow .`
 make
 ```
-3. Enjoy making an awesome website.
+3. Make the thing.
 <br><br>
 
 ### [🙍‍♂️](https://pbs.twimg.com/media/GYWlOmEXQAA9nWF?format=png&name=small) <!-- + People won't notice that the emoji is a link, makes for a good easter egg + --> Regular Users
-1. Install [Pandoc](https://pandoc.org/), if you are running Windows, the version of the installer that you want is `windows-x86_64`.
-2. Ignore the other dependency. It has no easy install method and all it does is automatically refresh your website when you make edits. You can just close the tab and open the html file when you make an edit.
-3. Create your website as a markdown file, using Pandoc's markdown formattng. [Here is an example file](https://raw.githubusercontent.com/owickstrom/the-monospace-web/refs/heads/main/index.md), compare it to the [live website](https://owickstrom.github.io/the-monospace-web/) to figure out what makes what. You can also [click here](https://garrettgman.github.io/rmarkdown/authoring_pandoc_markdown.html) to see a more in-depth formatting guide.
-4. Open your command line, navigate to your project's folder, and write the following command `pandoc --toc -s --css reset.css --css index.css -i yoursourcefile.md -o output.html --template=template.html`
+1. Install [Pandoc](https://pandoc.org/). If you are running Windows, the version of the installer that you want is `windows-x86_64`.
+2. Ignore the other dependency. It has no easy install method and all it does is automatically refresh your website when you make edits.
+3. From this repository, download the following files:
+	* reset.css (This file ensures everything works, don't touch it)
+	* index.css (This file controls the visual style for the website, modify only if you understand [CSS](https://www.youtube.com/watch?v=OEV8gMkCHXQ))
+	* template.html (This defines the structural layout for Monospace Web, don't touch it unless you understand [HTML](https://www.youtube.com/watch?v=ok-plXXHlWw))
+	* To download files from a repository, click on its name and it will allow you to inspect the individual file, then, on the right side of the page there should be a tiny button (next to a button that says "RAW") to download it.
+4  Create a folder anywhere in your computer and place the downloaded files inside. Your website will live here.
+5. Create your website as a markdown file, using Pandoc's markdown formattng. [Here is an example file](https://raw.githubusercontent.com/owickstrom/the-monospace-web/refs/heads/main/index.md), compare it to the [live website](https://owickstrom.github.io/the-monospace-web/) to figure out what makes what. You can also [click here](https://garrettgman.github.io/rmarkdown/authoring_pandoc_markdown.html) to see a more in-depth formatting guide.
+6. Open your command line, navigate to your project's folder, and write the following command `pandoc --toc -s --css reset.css --css index.css -i yoursourcefile.md -o output.html --template=template.html`
 	* You'll need to replace the file names with your own.
 	* You can and should automate this process with a batch script.
-6. test
+7. test
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ make
 5. Okay but how do I convert the md
 
 ### Regular Users
-https://pbs.twimg.com/media/GYWlOmEXQAA9nWF?format=png&name=small
+[There is currently no plug & play method to build websites using the Monospace Web.](https://pbs.twimg.com/media/GYWlOmEXQAA9nWF?format=png&name=small)
 
 ## License
 


### PR DESCRIPTION
The documentation assumes that the user is familiar with the tools & workflows involved. Considering that Monospace Web provides a really accessible way for users to build beautiful websites (just make a markdown file!), the lack of appropriate documentation that targets the lowest common denominator is a missed opportunity.

This pull request seeks to alleviate this problem by modifying the existing readme file to include detailed instructions for non-technical users, while also preserving the original build method for power users that can understand the whole process from a single nix command.

The easter egg included is meant as harmless fun and a critique of the maintainers. Considering that this isn't being sold and marketed for its inherent accessibility, and is instead hosted entirely on a website whose target demographic is programmers, it's only understandable to expect a smidget of technical knowhow from visitors. Plus being on github probably creates a bit of survivorship bias towards believing that the average person knows what nix is.
Regardless, I want to believe that the maintainers of this repo also want as many people as possible to use the Monospace Web, so I'm hoping that this documentation will be well received. There are many troglodytes like me who dislike package managers and much prefer to install dependencies by hand.

This updated documentation is meant to guide you from start to end. While originally, it gave you the tools and assumed you could piece together what to do from there. While users could be trusted to just google how to use Pandoc (and piece together from context that Pandoc is what is used to convert the md file to an html file), providing an exact command for them to use will probably replace a small handful of frowns with smiles.

Also, please kindly sqash before merging. In my weak defence, it is 1am.