### PR TITLE
feat(make): Add SRCDIR to Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,12 +1,13 @@
 VERSION=$(shell jq -r .version package.json)
 DATE=$(shell date +%F)
+SRCDIR ?= demo
 
 all: index.html
 
 clean:
 	rm -f index.html
 
-index.html: demo/index.md demo/template.html Makefile
-	pandoc --toc -s --css src/reset.css --css src/index.css -Vversion=v$(VERSION) -Vdate=$(DATE) -i $< -o $@ --template=demo/template.html
+index.html: $(SRCDIR)/index.md $(SRCDIR)/template.html Makefile
+	pandoc --toc -s --css src/reset.css --css src/index.css -Vversion=v$(VERSION) -Vdate=$(DATE) -i $< -o $@ --template=$(SRCDIR)/template.html
 
 .PHONY: all clean


### PR DESCRIPTION
The current Makefile expects the source files (`index.md` and `template.html`) in the `demo` directory. If another source directory is desired, the Makefile must be modified. This is can be the case if multiple `index.md` files are being maintained.

This change adds the `SRCDIR` variable and sets the default to `demo`. This allows for default behavior. If another source directory should be used the following command line works:

    SRCDIR=my-web-site make

This will cause the Makefile to look for `index.md` and `template.html` in the `my-web-site` directory.